### PR TITLE
Improved functionality on helfpul links

### DIFF
--- a/client/src/components/QuestionsAndAnswers/AnswerItem.jsx
+++ b/client/src/components/QuestionsAndAnswers/AnswerItem.jsx
@@ -8,7 +8,9 @@ const AnswerItem = (props) => {
 
   const [helpfulCount, setHelpfulCount] = useState(props.answer.helpfulness);
   const [reportDisable, setReportDisable] = useState(false);
-  const [reportFont, setReportFont] = useState('report-font')
+  const [helpfulDisable, setHelpfulDisable] = useState(false);
+  const [reportFont, setReportFont] = useState('report-font');
+  const [helpfulFont, setHelpfulFont] = useState('found-helpful-font');
   const [reportLabel, setReportLabel] = useState('Report');
   const [photoView, setPhotoView] = useState(false);
   const [image, setImage] = useState('');
@@ -31,15 +33,15 @@ const AnswerItem = (props) => {
     axios(options)
       .then(() => {
         console.log('user found answer helpful!');
-        if (userAction === 'helpful') {
+        if (userAction === 'helpful' && !helpfulDisable) {
           setHelpfulCount(helpfulCount + 1);
-        } else {
-          if (!reportDisable) {
-            console.log('user reported this answer');
-            setReportDisable(true);
-            setReportLabel('Reported');
-            setReportFont('reported-font');
-          }
+          setHelpfulDisable(true);
+          setHelpfulFont('pressed-helpful-font');
+        } else if (userAction === 'report' && !reportDisable) {
+          console.log('user reported this answer');
+          setReportDisable(true);
+          setReportLabel('Reported');
+          setReportFont('reported-font');
         }
       })
       .catch(err => {
@@ -51,7 +53,7 @@ const AnswerItem = (props) => {
   // PUT /qa/answers/:answer_id/report
 
 
-  let foundHelpful = (<div className="found-helpful-font" onClick={() => {handleUserAction('helpful')}} >Yes</div>);
+  let foundHelpful = (<div className={helpfulFont} onClick={() => {handleUserAction('helpful')}} >Yes</div>);
 
   let doReport = (<div className={reportFont} onClick={() => {handleUserAction('report')}} >{reportLabel}</div>);
 

--- a/client/src/components/QuestionsAndAnswers/QuestionItem.jsx
+++ b/client/src/components/QuestionsAndAnswers/QuestionItem.jsx
@@ -13,6 +13,8 @@ const QuestionItem = (props) => {
   const productContext = useContext(ProductContext);
   const product = productContext.productInfo.name;
   const [helpfulCount, setHelpfulCount] = useState(props.questionHelpfulness);
+  const [helpfulDisable, setHelpfulDisable] = useState(false);
+  const [helpfulFont, setHelpfulFont] = useState('found-question-helpful-font');
   const [modalVisible, setModalVisible] = useState(false);
 
 
@@ -29,7 +31,11 @@ const QuestionItem = (props) => {
     axios(options)
       .then(() => {
         console.log('user found question helpful!');
-        setHelpfulCount(helpfulCount + 1);
+        if (!helpfulDisable) {
+          setHelpfulCount(helpfulCount + 1);
+          setHelpfulDisable(true);
+          setHelpfulFont('pressed-question-helpful-font');
+        }
       })
       .catch(err => {
         console.log(err);
@@ -37,7 +43,7 @@ const QuestionItem = (props) => {
   };
 
 
-  let foundHelpful = (<div className="found-question-helpful-font" onClick={addHelpfulCount}>Yes</div>);
+  let foundHelpful = (<div className={helpfulFont} onClick={addHelpfulCount}>Yes</div>);
 
   let doAnswer = (<div className="add-answer-font" onClick={() => {handleAddAnswer()}} >Add Answer</div>);
 

--- a/client/src/styles/sections/_questions.scss
+++ b/client/src/styles/sections/_questions.scss
@@ -147,6 +147,10 @@
   color: rgba(138, 135, 135, 0.712);
 }
 
+.pressed-helpful-font {
+  @include mixins.theme(10px, 700);
+}
+
 .report-font {
   @include mixins.theme(10px, 400);
   text-decoration: underline;

--- a/client/src/styles/sections/_questions.scss
+++ b/client/src/styles/sections/_questions.scss
@@ -149,6 +149,7 @@
 
 .pressed-helpful-font {
   @include mixins.theme(10px, 700);
+  color: rgb(138, 135, 135);
 }
 
 .report-font {
@@ -176,6 +177,12 @@
   cursor: pointer;
   color: rgba(138, 135, 135, 0.712);
 }
+
+.pressed-question-helpful-font {
+  @include mixins.theme(12px, 700);
+  color: rgb(138, 135, 135);
+}
+
 
 .add-answer-font {
   @include mixins.theme(12px, 700);


### PR DESCRIPTION
Refactored helpful links on both questions and answers to:
- Only allow one helpful vote per user session
- Disables the helpful link post request
- Changes the font to visually show that the link has been disabled and the user has voted.

<img width="863" alt="Screen Shot 2021-11-11 at 4 39 33 PM" src="https://user-images.githubusercontent.com/65197354/141384332-3d1a4a6c-cf39-4f00-9ef4-c8fa079c618b.png">

